### PR TITLE
Use explicit write permissions for migration

### DIFF
--- a/deploy/docker-migrate.sh
+++ b/deploy/docker-migrate.sh
@@ -6,7 +6,7 @@ set -x   # print what we are doing
 
 # Default credentials are for read-only access to the database.
 # Migration needs write access, so overwrite the default credentials.
-DATABASE_USER=${DATABASE_USER_WRITE}
-DATABASE_PASSWORD=${DATABASE_PASSWORD_WRITE}
+export DATABASE_USER=${DATABASE_USER_WRITE}
+export DATABASE_PASSWORD=${DATABASE_PASSWORD_WRITE}
 
 python manage.py migrate --noinput

--- a/deploy/docker-migrate.sh
+++ b/deploy/docker-migrate.sh
@@ -4,4 +4,9 @@ set -u   # crash on missing env variables
 set -e   # stop on any error
 set -x   # print what we are doing
 
+# Default credentials are for read-only access to the database.
+# Migration needs write access, so overwrite the default credentials.
+DATABASE_USER=${DATABASE_USER_WRITE}
+DATABASE_PASSWORD=${DATABASE_PASSWORD_WRITE}
+
 python manage.py migrate --noinput


### PR DESCRIPTION
The CMDB sets DATABASE_USER_WRITE and DATABASE_USER_WRITE for the PostgreSQL write credentials. The default credentials (DATABASE_USER / DATABASE_PASSWORD) are read-only credentials.