### PR TITLE
Use bag_v11 database to get required bag table

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,10 +54,11 @@ env:                                ## Print current env
 	env | sort
 
 import_bag:                       ## Populate database with Bag data
-	${dc} exec database update-table.sh bag bag_verblijfsobject public iiif_metadata_server 
-	${dc} exec database update-table.sh bag bag_ligplaats public iiif_metadata_server 
-	${dc} exec database update-table.sh bag bag_standplaats public iiif_metadata_server 
-	${dc} exec database update-table.sh bag bag_nummeraanduiding public iiif_metadata_server 
-	${dc} exec database update-table.sh bag bag_pand public iiif_metadata_server 
-	${dc} exec database update-table.sh bag bag_verblijfsobjectpandrelatie public iiif_metadata_server 
-	${dc} exec database update-table.sh bag bag_openbareruimte public iiif_metadata_server 
+	${dc} exec database update-table.sh bag_v11 bag_verblijfsobject public iiif_metadata_server
+	${dc} exec database update-table.sh bag_v11 bag_ligplaats public iiif_metadata_server
+	${dc} exec database update-table.sh bag_v11 bag_standplaats public iiif_metadata_server
+	${dc} exec database update-table.sh bag_v11 bag_nummeraanduiding public iiif_metadata_server
+	${dc} exec database update-table.sh bag_v11 bag_pand public iiif_metadata_server
+	${dc} exec database update-table.sh bag_v11 bag_verblijfsobjectpandrelatie public iiif_metadata_server
+	${dc} exec database update-table.sh bag_v11 bag_openbareruimte public iiif_metadata_server
+	${dc} exec database psql -U postgres -c 'CREATE INDEX ON bag_nummeraanduiding(verblijfsobject_id)' iiif_metadata_server

--- a/deploy/import/import.sh
+++ b/deploy/import/import.sh
@@ -29,13 +29,14 @@ dc run importer /deploy/docker-migrate.sh
 echo "Load latest verblijfsobjecten, ligplaatsen, standplaatsen, nummeraanduidingen en panden in iiif-metadata-server database"
 
 # dc exec -T database update-db.sh atlas
-dc exec -T database update-table.sh bag bag_verblijfsobject public iiif_metadata_server
-dc exec -T database update-table.sh bag bag_ligplaats public iiif_metadata_server
-dc exec -T database update-table.sh bag bag_standplaats public iiif_metadata_server
-dc exec -T database update-table.sh bag bag_nummeraanduiding public iiif_metadata_server
-dc exec -T database update-table.sh bag bag_pand public iiif_metadata_server
-dc exec -T database update-table.sh bag bag_verblijfsobjectpandrelatie public iiif_metadata_server
-dc exec -T database update-table.sh bag bag_openbareruimte public iiif_metadata_server
+dc exec -T database update-table.sh bag_v11 bag_verblijfsobject public iiif_metadata_server
+dc exec -T database update-table.sh bag_v11 bag_ligplaats public iiif_metadata_server
+dc exec -T database update-table.sh bag_v11 bag_standplaats public iiif_metadata_server
+dc exec -T database update-table.sh bag_v11 bag_nummeraanduiding public iiif_metadata_server
+dc exec -T database update-table.sh bag_v11 bag_pand public iiif_metadata_server
+dc exec -T database update-table.sh bag_v11 bag_verblijfsobjectpandrelatie public iiif_metadata_server
+dc exec -T database update-table.sh bag_v11 bag_openbareruimte public iiif_metadata_server
+dc exec -T database psql -U postgres -c 'CREATE INDEX ON bag_nummeraanduiding(verblijfsobject_id)' iiif_metadata_server
 
 
 echo "Importing data"

--- a/src/bouwdossiers/batch.py
+++ b/src/bouwdossiers/batch.py
@@ -468,8 +468,7 @@ WITH adres_nummeraanduiding AS (
             END) AS nummeraanduidingen_label
     FROM bouwdossiers_adres ba
     JOIN bouwdossiers_bouwdossier bb ON bb.id = ba.bouwdossier_id
-    JOIN bag_verblijfsobject bv ON bv.landelijk_id = any(ba.verblijfsobjecten)
-    JOIN bag_nummeraanduiding bag_nra ON bag_nra.verblijfsobject_id = bv.id  -- bag_nra.verblijfsobject_id is het niet-landelijk verblijfsobjectid en daarom maken we de tussen-join mbv bag_verblijfsobject
+    JOIN bag_nummeraanduiding bag_nra ON bag_nra.verblijfsobject_id = ANY(ba.verblijfsobjecten)
     WHERE bb.source = 'WABO'
     GROUP BY ba.id)
 UPDATE bouwdossiers_adres


### PR DESCRIPTION
The bag database is obsolete so we need to use the bag_v11 database
In the bag_v11 tables the id is the same as the landelijk_id so we do
not need the extra join with bag_verblijfsobject table

We also add a extra index on bag_nummeraanduiding(verblijfsobject_id)
This speeds up the query to update nummeraanduidingen significantly