### PR TITLE
Fix static content required for Django Rest Framework

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
   database:
     image: amsterdam/postgres11
     ports:
-      - 5432:5432
+      - 5432
     environment:
       POSTGRES_DB: iiif_metadata_server
       POSTGRES_USER: iiif_metadata_server

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
   database:
     image: amsterdam/postgres11
     ports:
-      - 5432
+      - 5432:5432
     environment:
       POSTGRES_DB: iiif_metadata_server
       POSTGRES_USER: iiif_metadata_server
@@ -20,6 +20,7 @@ services:
       - 8000:8000
     environment:
       - SECRET_KEY
+      - UWSGI_STATIC_MAP=/iiif-metadata/static=/static
     volumes:
       - ./src:/src
       - ./deploy:/deploy
@@ -37,6 +38,7 @@ services:
       - DEBUG=true
       - SECRET_KEY=dev
       - PYTHONBREAKPOINT
+      - UWSGI_STATIC_MAP=/iiif-metadata/static=/static
     volumes:
       - ./src:/src
       - ./deploy:/deploy

--- a/src/bouwdossiers/batch.py
+++ b/src/bouwdossiers/batch.py
@@ -26,6 +26,7 @@ log = logging.getLogger(__name__)
 #   'ST': 'Zuidoost',
 #   'SN': 'Noord',
 #   'SW': 'Zuid',
+#   'XY': 'Bodemdossiers',
 # }
 
 # Bag stadsdeel codes

--- a/src/main/settings.py
+++ b/src/main/settings.py
@@ -96,7 +96,7 @@ USE_TZ = True
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/1.10/howto/static-files/
 
-STATIC_URL = '/static/'
+STATIC_URL = '/iiif-metadata/static/'
 STATIC_ROOT = os.path.abspath(os.path.join(BASE_DIR, '..', 'static'))
 
 # Django Logging settings
@@ -176,17 +176,7 @@ SWAGGER_SETTINGS = {
         'title': 'Bouwdossiers',
     },
 
-    'doc_expansion': 'list',
-    'SECURITY_DEFINITIONS': {
-        'oauth2': {
-            'type': 'oauth2',
-            'authorizationUrl': DATAPUNT_API_URL + "oauth2/authorize",
-            'flow': 'implicit',
-            'scopes': {
-                "BD/R": "Bouwdossiers access",
-            }
-        }
-    }
+    'doc_expansion': 'list'
 }
 
 HEALTH_MODEL = 'bouwdossiers.Bouwdossier'

--- a/src/main/urls.py
+++ b/src/main/urls.py
@@ -23,7 +23,9 @@ schema_view = get_schema_view(
         terms_of_service="https://data.amsterdam.nl/",
         contact=openapi.Contact(email="datapunt@amsterdam.nl"),
         license=openapi.License(name="CC0 1.0 Universal"),
-    )
+    ),
+    public=True,
+    permission_classes=(permissions.AllowAny,),
 )
 
 urlpatterns = [

--- a/src/main/urls.py
+++ b/src/main/urls.py
@@ -23,9 +23,7 @@ schema_view = get_schema_view(
         terms_of_service="https://data.amsterdam.nl/",
         contact=openapi.Contact(email="datapunt@amsterdam.nl"),
         license=openapi.License(name="CC0 1.0 Universal"),
-    ),
-    public=False,
-    permission_classes=(permissions.AllowAny,),
+    )
 )
 
 urlpatterns = [


### PR DESCRIPTION
The /static path is no longer served by HAProxy, so we need to
provide a project specific static path. This also requires a Openstack
change but then https://api.data.amsterdam.nl/iiif-metadata/bouwdossier/
will show the static content correctly.

Also expose the Postgres port to localhost for local access

Reenable Swagger again
Remove oauth authorization from Swagger definition