### PR TITLE
Fix static content.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,6 @@ services:
       - 8000:8000
     environment:
       - SECRET_KEY
-      - UWSGI_STATIC_MAP=/iiif-metadata/static=/static
     volumes:
       - ./src:/src
       - ./deploy:/deploy

--- a/src/main/uwsgi.ini
+++ b/src/main/uwsgi.ini
@@ -11,7 +11,7 @@ py-autoreload = 1
 
 http = :8000
 wsgi-file = main/wsgi.py
-route = /static/(.*) static:/src/static/$1
+route = /iiif-metadata/static/(.*) static:/static/$1
 
 buffer-size = 32768
 harakiri = 15


### PR DESCRIPTION
The endpoint /static is no longer served by HAProxy.
In this project the mapping for static files is  made with
the route configuration in the uwsgi.ini file. So there
it needs to be changed to /iiif-metadata/static/