### PR TITLE
Create indexes for id values bag tables.

### DIFF
--- a/deploy/import/import.sh
+++ b/deploy/import/import.sh
@@ -36,9 +36,6 @@ dc exec -T database update-table.sh bag_v11 bag_nummeraanduiding public iiif_met
 dc exec -T database update-table.sh bag_v11 bag_pand public iiif_metadata_server
 dc exec -T database update-table.sh bag_v11 bag_verblijfsobjectpandrelatie public iiif_metadata_server
 dc exec -T database update-table.sh bag_v11 bag_openbareruimte public iiif_metadata_server
-dc exec -T database psql iiif_metadata_server -U postgres -c 'ALTER TABLE bag_pand ADD PRIMARY KEY(id)'
-dc exec -T database psql iiif_metadata_server -U postgres -c 'ALTER TABLE bag_verblijfsobject ADD PRIMARY KEY(id)'
-dc exec -T database psql iiif_metadata_server -U postgres -c 'ALTER TABLE bag_nummeraanduiding ADD PRIMARY KEY(id)'
 
 
 echo "Importing data"

--- a/src/bouwdossiers/batch.py
+++ b/src/bouwdossiers/batch.py
@@ -539,6 +539,9 @@ CREATE INDEX IF NOT EXISTS bag_verblijfsobjectpandrelatie_pand_id_idx
     ON bag_verblijfsobjectpandrelatie(pand_id);
 CREATE INDEX IF NOT EXISTS bag_verblijfsobjectpandrelatie_verblijfsobject_id_idx
     ON bag_verblijfsobjectpandrelatie(verblijfsobject_id);
+CREATE INDEX IF NOT EXISTS bag_pand_id_idx ON bag_pand(id);
+CREATE INDEX IF NOT EXISTS bag_verblijfsobject_id_idx ON bag_verblijfsobject(id);
+CREATE INDEX IF NOT EXISTS bag_nummeraanduiding_id_idx ON bag_nummeraanduiding(id);
     """)
         # Set parameter to disable parallel query. On Postgres docker
         # parallel query can fail due to lack of /dev/shm shared memory


### PR DESCRIPTION
The bag tables are  loaded without primary key.
Adding the primary key wit ALTER statements in with
docker-compose fails becauise the statement cannot be passed.

There is no easy way to add primary keys with check if they exist
Therefore we add a index instead of the primary key to get the same
performance benefits.