### PR TITLE
Pass env variable in docker-compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ENV PYTHONUNBUFFERED 1 \
 ENV CONSUL_HOST=${CONSUL_HOST:-notset}
 ENV CONSUL_PORT=${CONSUL_PORT:-8500}
 ENV DATAPUNT_API_URL=${DATAPUNT_API_URL:-https://bouwdossiers.amsterdam.nl/}
-ARG JWKS_USE_TEST_KEY=true
+ARG JWKS_USE_TEST_KEY=${JWKS_USE_TEST_KEY}
 
 RUN apt-get update \
  && apt-get dist-upgrade -y \

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ENV PYTHONUNBUFFERED 1 \
 ENV CONSUL_HOST=${CONSUL_HOST:-notset}
 ENV CONSUL_PORT=${CONSUL_PORT:-8500}
 ENV DATAPUNT_API_URL=${DATAPUNT_API_URL:-https://bouwdossiers.amsterdam.nl/}
-ARG JWKS_USE_TEST_KEY=${JWKS_USE_TEST_KEY}
+ARG JWKS_USE_TEST_KEY=true
 
 RUN apt-get update \
  && apt-get dist-upgrade -y \

--- a/deploy/import/docker-compose.yml
+++ b/deploy/import/docker-compose.yml
@@ -22,6 +22,7 @@ services:
       DATABASE_NAME: iiif_metadata_server
       DATABASE_USER: iiif_metadata_server
       DATABASE_PASSWORD: insecure
+      JWKS_USE_TEST_KEY: ${JWKS_USE_TEST_KEY}
       MIN_BOUWDOSSIERS_COUNT:
     command: >
       bash -c "/deploy/import/docker-import-db.sh"

--- a/src/main/settings.py
+++ b/src/main/settings.py
@@ -71,7 +71,7 @@ JWKS_TEST_KEY = """
 if os.getenv('JWKS_USE_TEST_KEY', 'false').lower() == 'true':
     JWKS = JWKS_TEST_KEY
 else:
-    JWKS = os.getenv('PUB_JWKS')
+    JWKS = os.environ['PUB_JWKS']
 
 DATAPUNT_AUTHZ = {
     'ALWAYS_OK': False,

--- a/src/main/settings.py
+++ b/src/main/settings.py
@@ -68,8 +68,7 @@ JWKS_TEST_KEY = """
     }
 """
 
-JWKS_USE_TEST_KEY = os.getenv('JWKS_USE_TEST_KEY') and os.getenv('JWKS_USE_TEST_KEY').lower() == 'true'
-if JWKS_USE_TEST_KEY:
+if os.getenv('JWKS_USE_TEST_KEY', 'false').lower() == 'true':
     JWKS = JWKS_TEST_KEY
 else:
     JWKS = os.getenv('PUB_JWKS')

--- a/src/main/settings.py
+++ b/src/main/settings.py
@@ -68,10 +68,11 @@ JWKS_TEST_KEY = """
     }
 """
 
-if os.getenv('JWKS_USE_TEST_KEY', False):
+JWKS_USE_TEST_KEY = os.getenv('JWKS_USE_TEST_KEY') and os.getenv('JWKS_USE_TEST_KEY').lower() == 'true'
+if JWKS_USE_TEST_KEY:
     JWKS = JWKS_TEST_KEY
 else:
-    JWKS = os.environ['PUB_JWKS']
+    JWKS = os.getenv('PUB_JWKS')
 
 DATAPUNT_AUTHZ = {
     'ALWAYS_OK': False,


### PR DESCRIPTION
The importer does not get the env variable that is set in Jenkins. This should mitigate that and pass it along. In jenkins it seems that the import script is run locally, and it is, but it starts up another docker to execute the migrate script. And that docker does not have access to the env variable it needs without this change.

Do you agree with my changes in: `src/main/settings.py`? I am not sure why there were different methods of accessing the env variables. I changed it for consistency but if there is a specific reason for the difference I would love to learn it.