### PR TITLE
Force specific ports in docker compose override

### DIFF
--- a/docker-compose.override.yml.example
+++ b/docker-compose.override.yml.example
@@ -1,12 +1,22 @@
 services:
+  database:
+    ports: !override
+      - "5903:5432"
+  
+  azurite:
+    ports: !override
+      - "10010:10000"  # Blob service
+
   dev:
-    ports:
+    ports: 
       - "8002:8000"
     volumes:
       - ./src:/src
       - ./deploy:/deploy
       - ./src/importer/tests/data:/tmp/bouwdossiers
-
+    environment:
+      - AZURITE_STORAGE_CONNECTION_STRING=AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;DefaultEndpointsProtocol=http;BlobEndpoint=http://azurite:10010/devstoreaccount1/;
+  
   test:
     volumes:
       - ./src:/src

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,7 +41,7 @@ services:
   azurite:
     image: mcr.microsoft.com/azure-storage/azurite
     ports:
-      - "10010:10000"  # Blob service
+      - 10000 # Blob service
 
   app:
     <<: *base-app


### PR DESCRIPTION
The override was not correctly overriding the ports. This became an issue when the ports were used by another application. This solves the problem by forcing the override and not taking into account the ports set by the non-override