### PR TITLE
Add sdn bagids and skip nonwabofiles

### DIFF
--- a/src/importer/batch.py
+++ b/src/importer/batch.py
@@ -263,7 +263,7 @@ def add_wabo_dossier(
             openbareruimte_id = bag_id.get("openbareruimteidentificatie")
             nummeraanduidingen.append(bag_id.get("Nummeraanduidingidentificatie"))
 
-        elif x_adres.get("straatnaam") is not None:
+        elif x_adres.get("straatnaam") and x_adres.get("huisnummer"):
             # when no bag_ids in xml, try match straat&huisnummer with parameter BWT_ids jsonfile
             _straat_huisnummer = (
                 x_adres.get("straatnaam") + "_" + x_adres.get("huisnummer")
@@ -287,7 +287,7 @@ def add_wabo_dossier(
                     for item in _result["nummeraanduidingen"]
                 ]
             except:
-                log.warning("straat_huisnummer niet gevonden in BWT bestand")
+                log.warning(f"straat_huisnummer niet gevonden in BWT_TMLO.json voor {dossier} in {file_path}")
 
         locatie_aanduiding = x_adres.get("locatie_aanduiding")
         if type(locatie_aanduiding) is str and len(locatie_aanduiding) > 250:

--- a/src/importer/batch.py
+++ b/src/importer/batch.py
@@ -255,15 +255,16 @@ def add_wabo_dossier(
         openbareruimte_id = None
         nummeraanduidingen = []
 
-        if bag_id:  # if no bag_ids, locatie aanduiding is available.
+        if (
+            bag_id
+        ):  # if no bag_ids, check BWT_ids jsonfile and at last locatie aanduiding.
             panden.append(bag_id.get("pandidentificatie"))
             verblijfsobjecten.append(bag_id.get("verblijfsobjectidentificatie"))
             openbareruimte_id = bag_id.get("openbareruimteidentificatie")
             nummeraanduidingen.append(bag_id.get("Nummeraanduidingidentificatie"))
 
-        elif (
-            bron == "BWT"
-        ):  # in bwt-files no bag_ids (locatie aanduiding?) in xml, match with parameter BWT_ids jsonfile
+        elif x_adres.get("straatnaam") is not None:
+            # when no bag_ids in xml, try match straat&huisnummer with parameter BWT_ids jsonfile
             _straat_huisnummer = (
                 x_adres.get("straatnaam") + "_" + x_adres.get("huisnummer")
             )
@@ -595,7 +596,7 @@ def import_wabo_dossiers(root_dir=settings.DATA_DIR, max_file_count=None):  # no
     BWT_ids = _get_btw_verrijkings_bag_ids(root_dir)
 
     for file_path in glob.iglob(root_dir + "/**/*.xml", recursive=True):
-        wabo = re.search(r"/WABO/SD[A-Z]{1,2}( BWT)?/.+\.xml$|WABO_.+\.xml$", file_path)
+        wabo = re.search(r"/WABO/SD[A-Z]{1,2}( BWT)?/.+\.xml$", file_path)
         importfiles = models.ImportFile.objects.filter(name=file_path)
 
         if not wabo or len(importfiles) > 0:

--- a/src/importer/tests/data/WABO/BWT_TMLO.json
+++ b/src/importer/tests/data/WABO/BWT_TMLO.json
@@ -59,5 +59,25 @@
                 ]
             }
         ]
-    }
+    },
+    "SDN_P15-43398": {
+        "dossier_access": "PUBLIC",
+        "adressen": [
+            {
+                "straat_huisnummer": "staghof_49",
+                "straat": "staghof",
+                "huisnummer": "49",
+                "verblijfsobjecten": [
+                    "0363010000893549"
+                ],
+                "panden": [
+                    "0363100012140932"
+                ],
+                "openbareruimte_id": "0363300000005369",
+                "nummeraanduidingen": [
+                    "0363200000351193.3"
+                ]
+            }
+        ]
+    }    
 }


### PR DESCRIPTION
- Bag_id gegevens voor stadsdeel SDN wabo metadata zijn toegevoegd aan file BWT_TMLO.json -> code aangepast om deze ook uit te lezen voor wabo-key2 files.
- skip uitlezen nonwabofiles door directory anders uit te lezen.