### PR TITLE
Unique dossier barcode and use index as filenr in serializer

### DIFF
--- a/src/bouwdossiers/serializers.py
+++ b/src/bouwdossiers/serializers.py
@@ -53,18 +53,13 @@ class DocumentSerializer(ModelSerializer):
         result = super().to_representation(instance)
         _bestanden = []
 
-        for bestand in result["bestanden"]:
+        for index, bestand in enumerate(result["bestanden"]): 
             stadsdeel_dossiernr = (
                 f"{instance.bouwdossier.stadsdeel}_{instance.bouwdossier.dossiernr}"
             )
             f = re.search(r'\/([^\/]+)$', bestand)
             filename = f.group(1) if f else bestand
-            m_file = re.search(
-                r"_(\d+)\.\w{3,4}$", filename
-            )  # remove extension and get file/bestand number like 00001
-            filenr = (
-                int(m_file.group(1)) if m_file else 1
-            )  # file/bestand number else always first file
+            filenr = index
             file_reference = f"{stadsdeel_dossiernr}~{instance.barcode}_{filenr}"
             url = f"{settings.IIIF_BASE_URL}{dict(SOURCE_CHOICES)[instance.bouwdossier.source]}:{file_reference}"
 

--- a/src/bouwdossiers/serializers.py
+++ b/src/bouwdossiers/serializers.py
@@ -5,7 +5,6 @@ from django.conf import settings
 from rest_framework.reverse import reverse
 from rest_framework.serializers import HyperlinkedModelSerializer, ModelSerializer
 
-import bouwdossiers.constants as const
 from importer.models import (
     SOURCE_CHOICES,
     Adres,
@@ -53,11 +52,11 @@ class DocumentSerializer(ModelSerializer):
         result = super().to_representation(instance)
         _bestanden = []
 
-        for index, bestand in enumerate(result["bestanden"]): 
+        for index, bestand in enumerate(result["bestanden"]):
             stadsdeel_dossiernr = (
                 f"{instance.bouwdossier.stadsdeel}_{instance.bouwdossier.dossiernr}"
             )
-            f = re.search(r'\/([^\/]+)$', bestand)
+            f = re.search(r"\/([^\/]+)$", bestand)
             filename = f.group(1) if f else bestand
             filenr = index
             file_reference = f"{stadsdeel_dossiernr}~{instance.barcode}_{filenr}"

--- a/src/bouwdossiers/tests/test_api.py
+++ b/src/bouwdossiers/tests/test_api.py
@@ -209,7 +209,7 @@ class TestAPI(APITestCase):
         )
         self.assertEqual(
             response.data["results"][0]["documenten"][0]["bestanden"][0]["url"],
-            f"{settings.IIIF_BASE_URL}edepot:AA_111~ST100_1",
+            f"{settings.IIIF_BASE_URL}edepot:AA_111~ST100_0",
         )
         self.assertEqual(
             response.data["results"][0]["documenten"][0]["access"], "RESTRICTED"
@@ -412,7 +412,7 @@ class TestAPI(APITestCase):
         )
         self.assertEqual(
             response.data["results"][0]["documenten"][0]["bestanden"][0]["url"],
-            f"{settings.IIIF_BASE_URL}edepot:AA_TA-12345~ST100_1",
+            f"{settings.IIIF_BASE_URL}edepot:AA_TA-12345~ST100_0",
         )
         self.assertEqual(
             response.data["results"][0]["documenten"][0]["access"], "RESTRICTED"
@@ -510,7 +510,7 @@ class TestAPI(APITestCase):
         )
         self.assertEqual(
             response.data["results"][0]["documenten"][0]["bestanden"][0]["url"],
-            f"{settings.IIIF_BASE_URL}edepot:AA_TA-12345~ST100_1",
+            f"{settings.IIIF_BASE_URL}edepot:AA_TA-12345~ST100_0",
         )
         self.assertEqual(
             response.data["results"][0]["documenten"][0]["access"], "RESTRICTED"
@@ -580,15 +580,15 @@ class TestAPI(APITestCase):
         self.assertEqual(documents[0]["oorspronkelijk_pad"], ["/path/to/bestand"])
         self.assertEqual(
             documents[0]["bestanden"][0]["url"],
-            f"{settings.IIIF_BASE_URL}wabo:AA_TA-12345~1234567_9",
+            f"{settings.IIIF_BASE_URL}wabo:AA_TA-12345~1234567_0",
         )
         self.assertEqual(
             documents[0]["bestanden"][1]["url"],
-            f"{settings.IIIF_BASE_URL}wabo:AA_TA-12345~1234567_111112",
+            f"{settings.IIIF_BASE_URL}wabo:AA_TA-12345~1234567_1",
         )
         self.assertEqual(
             documents[0]["bestanden"][2]["url"],
-            f"{settings.IIIF_BASE_URL}wabo:AA_TA-12345~1234567_1",
+            f"{settings.IIIF_BASE_URL}wabo:AA_TA-12345~1234567_2",
         )
         self.assertEqual(adressen[0]["locatie_aanduiding"], "aanduiding")
         self.assertEqual(adressen[0]["huisnummer_letter"], "A")

--- a/src/importer/batch.py
+++ b/src/importer/batch.py
@@ -2,6 +2,7 @@ import glob
 import json
 import logging
 import re
+import zlib
 
 import xmltodict
 from django.conf import settings
@@ -392,12 +393,8 @@ def add_wabo_dossier(
 
         barcode = x_document.get("barcode")
         if not barcode and bestanden:
-            # This is the case with wabo dossiers, we use the name of the first bestand as the barcode
-            barcode = bestanden[0].split("/")[-1].split(".")[0].split("_")[0]
-            if type(barcode) is str:
-                barcode = barcode.replace(" ", "%20")
-            if type(barcode) is str and len(barcode) > 250:
-                log.error(f'The barcode str "{barcode}" is more than 250 characters')
+            # This is the case with wabo dossiers, we compress the name of the first bestand into an integer to use as barcode
+            barcode = zlib.crc32(bestanden[0].encode())
 
         document_omschrijving = x_document.get("document_omschrijving")
         if type(document_omschrijving) is str and len(document_omschrijving) > 250:

--- a/src/importer/batch.py
+++ b/src/importer/batch.py
@@ -295,7 +295,7 @@ def add_wabo_dossier(
                     for item in _result["nummeraanduidingen"]
                 ]
             except:
-                log.warning(f"straat_huisnummer niet gevonden in BWT_TMLO.json voor {dossier} in {file_path}")
+                log.info(f"straat_huisnummer niet gevonden in BWT_TMLO.json voor {_key}:{_straat_huisnummer} in {file_path}")
 
         locatie_aanduiding = x_adres.get("locatie_aanduiding")
         if type(locatie_aanduiding) is str and len(locatie_aanduiding) > 250:

--- a/src/importer/batch.py
+++ b/src/importer/batch.py
@@ -117,14 +117,14 @@ def openbaar_to_copyright(copyright):
 
 
 def get_dossier_access(_key, x_dossier, meta_ids: json):
-    # match with parameter jsonfile meta_ids - bwt files have no get_access element in xml's 
+    # match with parameter jsonfile meta_ids - bwt files have no get_access element in xml's
     # and some corrections are implemented in the jsonfile
     _key_ids = meta_ids.get(_key, {})
     if _key_ids == {}:
-        _test =get_access(x_dossier) 
+        get_access(x_dossier)
         return get_access(x_dossier)
     else:
-        _test = _key_ids.get("dossier_access", const.ACCESS_RESTRICTED)
+        _key_ids.get("dossier_access", const.ACCESS_RESTRICTED)
         return _key_ids.get("dossier_access", const.ACCESS_RESTRICTED)
 
 
@@ -295,7 +295,9 @@ def add_wabo_dossier(
                     for item in _result["nummeraanduidingen"]
                 ]
             except:
-                log.info(f"straat_huisnummer niet gevonden in BWT_TMLO.json voor {_key}:{_straat_huisnummer} in {file_path}")
+                log.info(
+                    f"straat_huisnummer niet gevonden in BWT_TMLO.json voor {_key}:{_straat_huisnummer} in {file_path}"
+                )
 
         locatie_aanduiding = x_adres.get("locatie_aanduiding")
         if type(locatie_aanduiding) is str and len(locatie_aanduiding) > 250:
@@ -469,7 +471,7 @@ def add_pre_wabo_dossier(
         stadsdeel = ""
         log.warning(f"Missing stadsdeel for bouwdossier {dossiernr} in {file_path}")
     _key = stadsdeel + "_" + dossiernr.zfill(5)
-    access = get_dossier_access(_key, x_dossier, meta_ids) 
+    access = get_dossier_access(_key, x_dossier, meta_ids)
     access_restricted_until = get_date_from_year(
         x_dossier.get("openbaarheidsBeperkingTot")
     )


### PR DESCRIPTION
- create unique barcode for wabo dossiers that dont have a barcode in de xml
-  use the index of the file in the list of bestanden in the serializer, to fix the difference between wabo files and edepot.